### PR TITLE
[BUGFIX] make bundle compatible to http-kernel 4.2

### DIFF
--- a/DataCollector/VCRDataCollector.php
+++ b/DataCollector/VCRDataCollector.php
@@ -58,4 +58,11 @@ class VCRDataCollector extends DataCollector
     {
         return 'vcr_collector';
     }
+
+    public function reset()
+    {
+        $this->data['requests'] = [];
+        $this->data['playbacks'] = [];
+        $this->data['count'] = 0;
+    }
 }


### PR DESCRIPTION
Hey!

By implementing reset(), the class is ready for http-kernel 4.2 seeing that DataCollectorInterface is now extending ResetInterface (https://github.com/symfony/http-kernel/blob/4.2/DataCollector/DataCollectorInterface.php).

Thanks!
By